### PR TITLE
fix: remove es2015 code that requires transpilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ exports.equal = function equal (a, b) {
   var keys = keyList(a);
   var length = keys.length;
 
-  for (let i = 0; i < length; i++)
+  for (var i = 0; i < length; i++)
     if (!(keys[i] in b)) return false;
 
-  for (let i = 0; i < length; i++)
+  for (var i = 0; i < length; i++)
     if (a[keys[i]] !== b[keys[i]]) return false;
 
   return length === keyList(b).length;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "testRegex": ".*/__tests__/.*\\.(test|spec)\\.(jsx?|tsx?)$",
     "reporters": [
       "jest-tap-reporter"
-    ]
+    ],
+    "testURL": "http://localhost"
   },
   "keywords": [
     "equal",


### PR DESCRIPTION
Hi @streamich, I started using `react-use` (BTW awesome library!) and noticed that due to the fact that `react-use` uses `fast-shallow-equal` [here](https://github.com/streamich/react-use/blob/ba8803eab26d2d48028a4b7120a7354c6d318aea/src/useShallowCompareEffect.ts#L2), my build ended up with es2015 code even after babel transpilation, since I exclude `node_modules` from babel transpilation.

This PR fixes the issue. I also added `testURL` param to jest config to make tests work again.

For now I updated my `babel-loader` config to also transpile `fast-shallow-equal` but would be nice to fix this so I can remove my "hack" :rocket:  

Here's a repro showing that production bundle still has the es2015 code: https://github.com/wagoid/bug-fast-shallow-equal