### PR TITLE
chore: add license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     ],
     "testURL": "http://localhost"
   },
+  "license": "Unlicense",
   "keywords": [
     "equal",
     "fast",


### PR DESCRIPTION
Hi, could you please add this license field?
As I was using [sonatype IQ server](https://support.sonatype.com/hc/en-us/articles/360000392428), when I use react-use package, it found 2 dependencies have license threats(fast-shallow-equal and react-universal-interface) as License-None, cause sonatype IQ server recognizes license status by checking package.json license field.